### PR TITLE
add "autogen autoconf libtool" to list of packages

### DIFF
--- a/electrum_grs/gui/kivy/tools/Dockerfile
+++ b/electrum_grs/gui/kivy/tools/Dockerfile
@@ -98,7 +98,7 @@ RUN dpkg --add-architecture i386 \
         build-essential ccache git python3 python3-dev \
         libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 \
         libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 \
-        zip zlib1g-dev zlib1g:i386 \
+        zip zlib1g-dev zlib1g:i386 autogen autoconf libtool\
     && apt -y autoremove \
     && apt -y clean
 


### PR DESCRIPTION
needed to build libffi, which is necessary for ctypes.