### PR TITLE
KeepKey: Fix testnet coin name

### DIFF
--- a/electrum_grs/plugins/keepkey/keepkey.py
+++ b/electrum_grs/plugins/keepkey/keepkey.py
@@ -154,7 +154,7 @@ class KeepKeyPlugin(HW_PluginBase):
         return client
 
     def get_coin_name(self):
-        return "Groestlcoin Testnet" if constants.net.TESTNET else "Groestlcoin"
+        return "GRS Testnet" if constants.net.TESTNET else "Groestlcoin"
 
     def initialize_device(self, device_id, wizard, handler):
         # Initialization method


### PR DESCRIPTION
KeepKey uses "GRS Testnet" coin name in firmware, because "Groestlcoin Testnet" was too long.